### PR TITLE
Fix LaTeX escaping for PDF color spans

### DIFF
--- a/ALCHEMY-Using_ubiquitous_bash-span_color.lua
+++ b/ALCHEMY-Using_ubiquitous_bash-span_color.lua
@@ -17,6 +17,7 @@ function M.RawBlock(elem)
       t = t:gsub('([\\{}])', '\\%1')
       t = t:gsub('([#%%$&_])', '\\%1')
       t = t:gsub('&amp;', '&'):gsub('&quot;', '"')
+      t = t:gsub('"', '\\textquotedbl{}')
       t = t:gsub('([%^~])', '\\%1{}')
       return t
     end


### PR DESCRIPTION
## Summary
- fix escaping of double quotes in Pandoc Lua filter

## Testing
- `pandoc --verbose --standalone --defaults=ALCHEMY-Using_ubiquitous_bash.yaml ALCHEMY-Using_ubiquitous_bash.md -o ALCHEMY-Using_ubiquitous_bash.pdf`

------
https://chatgpt.com/codex/tasks/task_e_686146c27004832ca4b7d76cc2b02e94